### PR TITLE
Refactored the IRouteInvocationInterceptor interface and usage hereof.

### DIFF
--- a/ExampleServer/DemoRouteInvocationInterceptor.cs
+++ b/ExampleServer/DemoRouteInvocationInterceptor.cs
@@ -1,12 +1,11 @@
-﻿using ExampleServer.MqttControllers;
-using Microsoft.Extensions.Logging;
-using MQTTnet;
+﻿using Microsoft.Extensions.Logging;
 using MQTTnet.AspNetCore.Routing.Routing;
+using MQTTnet.Server;
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
-namespace ExampleServer
-{
+namespace ExampleServer {
     public class DemoRouteInvocationInterceptor : IRouteInvocationInterceptor
     {
         private readonly ILogger _logger;
@@ -15,17 +14,36 @@ namespace ExampleServer
         {
             _logger = logger;
         }
-        public Task RouteExecuted(object o, Exception ex)
+
+        public Task<object> RouteExecuting( InterceptingPublishEventArgs publishEventArgs ) 
         {
-            _logger.LogInformation($" {ex.Message}");
+            Debug.Assert( publishEventArgs != null );
+
+            var correlationObject = new CorrelationObject 
+            {
+                Stopwatch = Stopwatch.StartNew(),
+                ClientId = publishEventArgs.ClientId, 
+                Topic = publishEventArgs.ApplicationMessage.Topic 
+            };
+
+            _logger.LogInformation( $"Before - {correlationObject.ClientId},{correlationObject.Topic}" );
+            return Task.FromResult<object>( correlationObject );
+        }
+
+        public Task RouteExecuted( object o, InterceptingPublishEventArgs publishEventArgs, Exception ex ) {
+            Debug.Assert( o != null );
+            Debug.Assert( o.GetType() == typeof( CorrelationObject ) );
+
+            var correlationObject = (CorrelationObject)o;
+            _logger.LogInformation( $"After - {correlationObject.ClientId},{correlationObject.Topic},{correlationObject.Stopwatch.ElapsedMilliseconds},{ex?.Message}" );
             return Task.CompletedTask;
         }
 
-        public Task<object> RouteExecuting(string clientId, MqttApplicationMessage applicationMessage)
+        private class CorrelationObject 
         {
-            object obj = new { clientId, applicationMessage.Topic };
-            _logger.LogInformation($"{clientId},{applicationMessage.Topic}");
-            return Task.FromResult(obj);
+            public string ClientId { get; set; }
+            public string Topic { get; set; }
+            public Stopwatch Stopwatch { get; set; }
         }
     }
 }

--- a/Source/Routing/IRouteInvocationInterceptor.cs
+++ b/Source/Routing/IRouteInvocationInterceptor.cs
@@ -1,26 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using MQTTnet.Server;
+using System;
 using System.Threading.Tasks;
 
-namespace MQTTnet.AspNetCore.Routing.Routing
-{
+namespace MQTTnet.AspNetCore.Routing.Routing {
     public interface IRouteInvocationInterceptor
     {
         /// <summary>
         /// Executed before the route handler is executed
         /// </summary>
-        /// <param name="clientId">The identifier of sender of the message</param>
-        /// <param name="applicationMessage">The message being handled</param>
+        /// <param name="publishEventArgs">An instance of <see cref="InterceptingPublishEventArgs"/>, containing information about the message received, such as the <see cref="InterceptingPublishEventArgs.ClientId"/> and <see cref="InterceptingPublishEventArgs.ApplicationMessage"/>.</param>
         /// <returns>Returns an opague object that may be used to correlate before- and after route execution. May be null</returns>
-        Task<object> RouteExecuting(string clientId, MqttApplicationMessage applicationMessage);
+        Task<object> RouteExecuting( InterceptingPublishEventArgs publishEventArgs );
 
         /// <summary>
         /// Executed after the route handler has been executed.
         /// </summary>
-        /// <param name="o">Set to the the response of <see cref="RouteExecuting(string, MqttApplicationMessage)"/>. May be null.</param>
-        /// <param name="ex">An exception if the route handler failed. Otherwise null.</param>
+        /// <param name="correlationObject">Set to the the response of <see cref="RouteExecuting(InterceptingPublishEventArgs)"/>. May be null.</param>
+        /// <param name="publishEventArgs">An instance of <see cref="InterceptingPublishEventArgs"/>, containing information about the reponse, such as <see cref="InterceptingPublishEventArgs.ProcessPublish"/> and the <see cref="InterceptingPublishEventArgs.Response"/>.</param>
+        /// <param name="ex">An exception if the route handler failed, otherwise null.</param>
         /// <returns></returns>
-        Task RouteExecuted(object o, Exception ex);
+        Task RouteExecuted(object correlationObject, InterceptingPublishEventArgs publishEventArgs, Exception ex );
     }
 }


### PR DESCRIPTION
The RouterInvocationInterceptor should receive the 'correlationObject' returned from 'RouteExecuting' in the call to 'RouteExecuted'. The interceptor can then correlate between the before- and the after calls and for instance, as shown in the example implementation, record the time it took to execute the route.