### PR TITLE
Update MQTTnet to 5.x.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -341,3 +341,6 @@ healthchecksdb
 
 # VsCode
 .vscode/
+
+# MacOS
+.DS_Store

--- a/ExampleClient/ExampleClient.csproj
+++ b/ExampleClient/ExampleClient.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MQTTnet.Extensions.ManagedClient" Version="4.3.2.930" />
+    <PackageReference Include="MQTTnet.Extensions.ManagedClient" Version="4.3.7.1207" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/MQTTnet.AspNetCore.Routing.csproj
+++ b/Source/MQTTnet.AspNetCore.Routing.csproj
@@ -40,7 +40,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MQTTnet" Version="4.3.2.930" />
-		<PackageReference Include="MQTTnet.AspNetCore" Version="4.3.2.930" />
+		<PackageReference Include="MQTTnet" Version="4.3.7.1207" />
+		<PackageReference Include="MQTTnet.AspNetCore" Version="4.3.7.1207" />
 	</ItemGroup>
 </Project>

--- a/Source/MQTTnet.AspNetCore.Routing.csproj
+++ b/Source/MQTTnet.AspNetCore.Routing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Description>
 			This is a support library to integrate AttributeRouting into MQTTnet with AspNetCore.
@@ -13,13 +13,13 @@
 		<PackageTags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin Blazor AspNetCore</PackageTags>
 		<Company>Atlas Lift Tech Inc;IoTSharp</Company>
 		<Authors>Anton Vishnyak;maikebing</Authors>
-		<AssemblyVersion>0.4.0</AssemblyVersion>
-		<FileVersion>0.4.0</FileVersion>
+		<AssemblyVersion>0.5.0</AssemblyVersion>
+		<FileVersion>0.5.0</FileVersion>
 		<LangVersion>default</LangVersion>
 		<RepositoryUrl>https://github.com/IoTSharp/MQTTnet.AspNetCore.Routing</RepositoryUrl>
 		<RepositoryType>GIT</RepositoryType>
 		<PackageReleaseNotes>* Added support for passing an array of assemblies to use in route discovery</PackageReleaseNotes>
-		<Version>0.4.0</Version>
+		<Version>0.5.0</Version>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageProjectUrl>https://github.com/IoTSharp/MQTTnet.AspNetCore.Routing</PackageProjectUrl>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -32,11 +32,6 @@
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
 			<_Parameter1>MQTTnet.AspNetCore.Routing.Tests</_Parameter1>
 		</AssemblyAttribute>
-	</ItemGroup>
- 
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/MQTTnet.AspNetCore.Routing.csproj
+++ b/Source/MQTTnet.AspNetCore.Routing.csproj
@@ -40,7 +40,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MQTTnet" Version="4.3.7.1207" />
-		<PackageReference Include="MQTTnet.AspNetCore" Version="4.3.7.1207" />
+		<PackageReference Include="MQTTnet" Version="5.0.1.1416" />
+		<PackageReference Include="MQTTnet.AspNetCore" Version="5.0.1.1416" />
 	</ItemGroup>
 </Project>

--- a/Source/Routing/MqttRouter.cs
+++ b/Source/Routing/MqttRouter.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using MQTTnet.AspNetCore.Routing.Attributes;
 using MQTTnet.Server;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -186,7 +187,7 @@ namespace MQTTnet.AspNetCore.Routing
             {
                 JsonSerializerOptions? defaultOptions =
                     serviceProvider.GetService<MqttRoutingOptions>()?.SerializerOptions;
-                return JsonSerializer.Deserialize(controllerContext.MqttContext.ApplicationMessage.Payload,
+                return JsonSerializer.Deserialize((ReadOnlySpan<byte>)controllerContext.MqttContext.ApplicationMessage.Payload.ToArray(),
                     param.ParameterType,
                     defaultOptions
                 );

--- a/Tests/MQTTnet.AspNetCore.Routing.Tests/MQTTnet.AspNetCore.Routing.Tests.csproj
+++ b/Tests/MQTTnet.AspNetCore.Routing.Tests/MQTTnet.AspNetCore.Routing.Tests.csproj
@@ -10,9 +10,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.7.1" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.7.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\Source\MQTTnet.AspNetCore.Routing.csproj" />


### PR DESCRIPTION
Limited framework support

MQTTnet 5 only supports newer (and still supported) .NET versions starting with version 8.0. MQTTnet will start to drop support for frameworks as soon as support has officially ended by Microsoft.

Changing the strategy ensures that the limited resources of this project can be used to implement new features faster. It also allows us to make use of new features like Memory<> or Span<> etc. which allowes improving the memory usage and performance of this library.

source: [https://github.com/dotnet/MQTTnet/wiki/Upgrading-guide](https://github.com/dotnet/MQTTnet/wiki/Upgrading-guide)

I made a commit with the last 4.3.7.1207 MQTTnet version for old .net Version.

- [❌] Not tested