### PR TITLE
Allow override start point for MqttRouter

### DIFF
--- a/Source/Extensions/IPublishEventProvider.cs
+++ b/Source/Extensions/IPublishEventProvider.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Atlas Lift Tech Inc. All rights reserved.
+
+using MQTTnet.Server;
+using System;
+using System.Threading.Tasks;
+
+namespace MQTTnet.AspNetCore.Routing;
+
+/// <summary>
+/// OnPublish provider allowing to trigger the Routing flow
+/// </summary>
+public interface IPublishEventProvider
+{
+    /// <summary>
+    /// OnPublishAsync will by the MqttRouter
+    /// </summary>
+    event Func<InterceptingPublishEventArgs, Task> OnPublishAsync;
+}

--- a/Source/Extensions/ServerEventProvider.cs
+++ b/Source/Extensions/ServerEventProvider.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Atlas Lift Tech Inc. All rights reserved.
+
+using MQTTnet.Server;
+using System;
+using System.Threading.Tasks;
+
+namespace MQTTnet.AspNetCore.Routing;
+
+internal sealed class ServerEventProvider : IPublishEventProvider
+{
+    private readonly MqttServer _server;
+
+    public ServerEventProvider(MqttServer server)
+    {
+        _server = server;
+    }
+
+    public event Func<InterceptingPublishEventArgs, Task> OnPublishAsync
+    {
+        add => _server.InterceptingPublishAsync += value;
+        remove => _server.InterceptingPublishAsync -= value;
+    }
+}

--- a/Source/Extensions/ServiceCollectionExtensions.cs
+++ b/Source/Extensions/ServiceCollectionExtensions.cs
@@ -103,12 +103,16 @@ namespace MQTTnet.AspNetCore.Routing
 
         public static void WithAttributeRouting(this MqttServer server, IServiceProvider svcProvider, bool allowUnmatchedRoutes = false)
         {
+            server.WithAttributeRouting(svcProvider, new ServerEventProvider(server), allowUnmatchedRoutes);
+        }
+
+        public static void WithAttributeRouting(this MqttServer server, IServiceProvider svcProvider, IPublishEventProvider publishEventProvider, bool allowUnmatchedRoutes = false)
+        {
             var router = svcProvider.GetRequiredService<MqttRouter>();
             router.Server = server;
             IRouteInvocationInterceptor? interceptor = svcProvider.GetService<IRouteInvocationInterceptor>();
-            IPublishEventProvider publishEvenProvider = svcProvider.GetService<IPublishEventProvider>() ?? new ServerEventProvider(server);
 
-            publishEvenProvider.OnPublishAsync += async (args) =>
+            publishEventProvider.OnPublishAsync += async (args) =>
             {
                 object correlationObject = null;
                 if (interceptor != null)

--- a/Source/Extensions/ServiceCollectionExtensions.cs
+++ b/Source/Extensions/ServiceCollectionExtensions.cs
@@ -96,11 +96,19 @@ namespace MQTTnet.AspNetCore.Routing
 
         public static IApplicationBuilder UseAttributeRouting(this IApplicationBuilder app, bool allowUnmatchedRoutes = false)
         {
-            var router = app.ApplicationServices.GetRequiredService<MqttRouter>();
             var server = app.ApplicationServices.GetRequiredService<MqttServer>();
+            server.WithAttributeRouting(app.ApplicationServices, allowUnmatchedRoutes);
+            return app;
+        }
+
+        public static void WithAttributeRouting(this MqttServer server, IServiceProvider svcProvider, bool allowUnmatchedRoutes = false)
+        {
+            var router = svcProvider.GetRequiredService<MqttRouter>();
             router.Server = server;
-            var interceptor = app.ApplicationServices.GetService<IRouteInvocationInterceptor>();
-            server.InterceptingPublishAsync += async (args) =>
+            IRouteInvocationInterceptor? interceptor = svcProvider.GetService<IRouteInvocationInterceptor>();
+            IPublishEventProvider publishEvenProvider = svcProvider.GetService<IPublishEventProvider>() ?? new ServerEventProvider(server);
+
+            publishEvenProvider.OnPublishAsync += async (args) =>
             {
                 object correlationObject = null;
                 if (interceptor != null)
@@ -110,46 +118,12 @@ namespace MQTTnet.AspNetCore.Routing
 
                 try
                 {
-                    await router.OnIncomingApplicationMessage(app.ApplicationServices, args, allowUnmatchedRoutes);
-
-                    if (interceptor != null)
-                    {
-                        await interceptor.RouteExecuted(correlationObject, args, null);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    if (interceptor != null)
-                    {
-                        await interceptor.RouteExecuted(correlationObject, args, ex);
-                    }
-                    throw;
-                }
-            };
-            return app;
-        }
-
-        public static void WithAttributeRouting(this MqttServer server, IServiceProvider svcProvider, bool allowUnmatchedRoutes = false)
-        {
-            var router = svcProvider.GetRequiredService<MqttRouter>();
-            router.Server = server;
-            var interceptor = svcProvider.GetService<IRouteInvocationInterceptor>();
-            server.InterceptingPublishAsync += async (args) =>
-            {
-                object correlationObject = null;
-                if (interceptor != null)
-                {
-                    correlationObject = await interceptor.RouteExecuting( args );
-                }
-
-                try
-                {
                     await router.OnIncomingApplicationMessage(svcProvider, args, allowUnmatchedRoutes);
                     if (interceptor != null)
                     {
                         await interceptor.RouteExecuted(correlationObject, args, null);
                     }
-                } 
+                }
                 catch (Exception ex)
                 {
                     if (interceptor != null)


### PR DESCRIPTION
Allow overriding when MqttRouter can start its process

This allows the creation of a new entry point when the Mqtt controller is executed

We have an issue that is  affecting us, and we need to send a PubAck before handling the message on our side
https://github.com/dotnet/MQTTnet/issues/1969
