### PR TITLE
Add MqttRoutingOptions.FromAssemblies to support explicit controller assembly discovery

### DIFF
--- a/Source/Extensions/ServiceCollectionExtensions.cs
+++ b/Source/Extensions/ServiceCollectionExtensions.cs
@@ -85,6 +85,11 @@ namespace MQTTnet.AspNetCore.Routing
             return opt;
         }
 
+        public static MqttRoutingOptions FromAssemblies(this MqttRoutingOptions opt, params Assembly[] assemblies)
+        {
+            opt.FromAssemblies = assemblies;
+            return opt;
+        }
 
         [Obsolete("Use 'services.AddMqttControllers(opt => opt.SerializerOptions= new JsonSerializerOptions());' instead ")]
         public static IServiceCollection AddMqttDefaultJsonOptions(this IServiceCollection services,


### PR DESCRIPTION
This PR adds `FromAssemblies` to `MqttRoutingOptions` so `AddMqttControllers()` can use explicit assembly discovery rather than relying on default `Assembly.GetEntryAssembly()`.

In containerized integration tests (e.g., WebApplicationFactory), GetEntryAssembly() is the  test host project, which often does not include our MQTT controller types ([MqttController]). As a result, routing table is empty and MQTT messages are seen as "not consumed" even though controller methods exist.

### Changes included

ServiceCollectionExtensions (MQTTnet.AspNetCore.Routing)

new method:
`
public static MqttRoutingOptions FromAssemblies(this MqttRoutingOptions opt, params Assembly[] assemblies)
{
    opt.FromAssemblies = assemblies;
    return opt;
}
`

### Why this matters

Fixes non-deterministic route discovery in integration tests.
Matches behavior of ASP.NET MVC/Endpoint routing where explicit route assembly source is supported.
Required for test frameworks where entry assembly is not the web app object.

### Example usage

`
services.AddMqttControllers(opt =>
{
    opt.FromAssemblies(typeof(Startup).Assembly);
});
`